### PR TITLE
Prevent NullPointerException

### DIFF
--- a/src/main/java/ixa/kaflib/AnnotationContainer.java
+++ b/src/main/java/ixa/kaflib/AnnotationContainer.java
@@ -757,7 +757,10 @@ class AnnotationContainer implements Serializable {
     List<Term> getTermsByWFIds(List<String> wfIds) {
 	LinkedHashSet<Term> terms = new LinkedHashSet<Term>();
 	for (String wfId : wfIds) {
-	    terms.addAll(this.termsIndexedByWF.get(wfId));
+	    List<Term> newTerms = this.termsIndexedByWF.get(wfId);
+	    if (newTerms != null) {
+	        terms.addAll(newTerms);
+	    }
 	}
 	return new ArrayList<Term>(terms);
     }


### PR DESCRIPTION
When converting other formats to NAF one might not know that he needs to add a &lt;term&gt; for every &lt;wf&gt;. The resulting NullPointerException is not trivial to debug.
