### PR TITLE
change xml character escaping to rely on apache commons StringEscapeUtils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ octave-core
 /src/test/
 /release.sh
 /generate_javadoc.sh
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+		<groupId>org.apache.commons</groupId>
+		<artifactId>commons-lang3</artifactId>
+		<version>3.4</version>
+	</dependency>	
   </dependencies>
 
   <build>

--- a/src/main/java/ixa/kaflib/ReadWriteManager.java
+++ b/src/main/java/ixa/kaflib/ReadWriteManager.java
@@ -33,6 +33,9 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.regex.*;
 
+// xml entity conversion (isanvicente) 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 //todo: read facts and linkedEntities
 
 /** Reads XML files in KAF format and loads the content in a KAFDocument object, and writes the content into XML files. */
@@ -1452,7 +1455,7 @@ class ReadWriteManager {
 	if (marks.size() > 0) {
 	    Element marksElem = new Element("markables");
 	    for (Mark mark : marks) {
-		Comment markComment = new Comment(cleanUnicode(mark.getStr()));
+		Comment markComment = new Comment(StringEscapeUtils.escapeXml11(mark.getStr()));
 		marksElem.addContent(markComment);
 		Element markElem = new Element("mark");
 		markElem.setAttribute("id", mark.getId());
@@ -1502,7 +1505,7 @@ class ReadWriteManager {
 	if (deps.size() > 0) {
 	    Element depsElem = new Element("deps");
 	    for (Dep dep : deps) {
-		Comment depComment = new Comment(cleanUnicode(dep.getStr()));
+		Comment depComment = new Comment(StringEscapeUtils.escapeXml11(dep.getStr()));
 		depsElem.addContent(depComment);
 		Element depElem = new Element("dep");
 		depElem.setAttribute("from", dep.getFrom().getId());
@@ -1520,7 +1523,7 @@ class ReadWriteManager {
 	if (chunks.size() > 0) {
 	    Element chunksElem = new Element("chunks");
 	    for (Chunk chunk : chunks) {
-		Comment chunkComment = new Comment(cleanUnicode(chunk.getStr()));
+		Comment chunkComment = new Comment(StringEscapeUtils.escapeXml11(chunk.getStr()));
 		chunksElem.addContent(chunkComment);
 		Element chunkElem = new Element("chunk");
 		chunkElem.setAttribute("id", chunk.getId());
@@ -1557,7 +1560,7 @@ class ReadWriteManager {
 		}
 		Element referencesElem = new Element("references");
 		for (Span<Term> span : entity.getSpans()) {
-		    Comment spanComment = new Comment(cleanUnicode(entity.getSpanStr(span)));
+		    Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(entity.getSpanStr(span)));
 		    referencesElem.addContent(spanComment);
 		    Element spanElem = new Element("span");
 		    for (Term term : span.getTargets()) {
@@ -1591,7 +1594,7 @@ class ReadWriteManager {
 		    corefElem.setAttribute("type", coref.getType());
 		}
 		for (Span<Term> span : coref.getSpans()) {
-		    Comment spanComment = new Comment(cleanUnicode(coref.getSpanStr(span)));
+		    Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(coref.getSpanStr(span)));
 		    corefElem.addContent(spanComment);
 		    Element spanElem = new Element("span");
 		    for (Term target : span.getTargets()) {
@@ -1657,7 +1660,7 @@ class ReadWriteManager {
 		}
 		if (timex3.hasSpan()) {
 		    Span<WF> span = timex3.getSpan();
-		    Comment spanComment = new Comment(cleanUnicode(timex3.getSpanStr(span)));
+		    Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(timex3.getSpanStr(span)));
 		    timex3Elem.addContent(spanComment);
 		    Element spanElem = new Element("span");
 		    for (WF target : span.getTargets()) {
@@ -1672,7 +1675,7 @@ class ReadWriteManager {
 		}
 		/*
 		for (Span<WF> span : timex3.getSpans()) {
-		    Comment spanComment = new Comment(cleanUnicode(timex3.getSpanStr(span)));
+		    Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(timex3.getSpanStr(span)));
 		    timex3Elem.addContent(spanComment);
 		    Element spanElem = new Element("span");
 		    for (WF target : span.getTargets()) {
@@ -1698,7 +1701,7 @@ class ReadWriteManager {
 			Element factElem = new Element("factuality");
 			factElem.setAttribute("id", f.getId());
 			Span<Term> span = f.getSpan();
-			Comment spanComment = new Comment(cleanUnicode(f.getSpanStr(span)));
+			Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(f.getSpanStr(span)));
 			factElem.addContent(spanComment);
 			Element spanElem = new Element("span");
 			for (Term term : span.getTargets()) {
@@ -1750,7 +1753,7 @@ class ReadWriteManager {
 			lEnt.setAttribute("reference", e.getReference());
 			lEnt.setAttribute("confidence", Double.toString(e.getConfidence()));
 
-			Comment spanComment = new Comment(cleanUnicode(e.getSpanStr()));
+			Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(e.getSpanStr()));
 			lEnt.addContent(spanComment);
 			Element spanElem = new Element("span");
 			for (WF target : e.getWFs().getTargets()) {
@@ -1776,7 +1779,7 @@ class ReadWriteManager {
 		List<Span<Term>> references = property.getSpans();
 		Element referencesElem = new Element("references");
 		for (Span<Term> span : references) {
-		    Comment spanComment = new Comment(cleanUnicode(property.getSpanStr(span)));
+		    Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(property.getSpanStr(span)));
 		    referencesElem.addContent(spanComment);
 		    Element spanElem = new Element("span");
 		    for (Term term : span.getTargets()) {
@@ -1804,7 +1807,7 @@ class ReadWriteManager {
 		List<Span<Term>> references = category.getSpans();
 		Element referencesElem = new Element("references");
 		for (Span<Term> span : references) {
-		    Comment spanComment = new Comment(cleanUnicode(category.getSpanStr(span)));
+		    Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(category.getSpanStr(span)));
 		    referencesElem.addContent(spanComment);
 		    Element spanElem = new Element("span");
 		    for (Term term : span.getTargets()) {
@@ -1838,7 +1841,7 @@ class ReadWriteManager {
 		    if (holder.hasType()) {
 			opinionHolderElem.setAttribute("type", holder.getType());
 		    }
-		    Comment comment = new Comment(cleanUnicode(opinion.getSpanStr(opinion.getOpinionHolder().getSpan())));
+		    Comment comment = new Comment(StringEscapeUtils.escapeXml11(opinion.getSpanStr(opinion.getOpinionHolder().getSpan())));
 		    opinionHolderElem.addContent(comment);
 		    List<Term> targets = holder.getTerms();
 		    Span<Term> span = holder.getSpan();
@@ -1859,7 +1862,7 @@ class ReadWriteManager {
 		Opinion.OpinionTarget opTarget = opinion.getOpinionTarget();
 		if (opTarget != null) {
 		    Element opinionTargetElem = new Element("opinion_target");
-		    Comment comment = new Comment(cleanUnicode(opinion.getSpanStr(opinion.getOpinionTarget().getSpan())));
+		    Comment comment = new Comment(StringEscapeUtils.escapeXml11(opinion.getSpanStr(opinion.getOpinionTarget().getSpan())));
 		    opinionTargetElem.addContent(comment);
 		    List<Term> targets = opTarget.getTerms();
 		    Span<Term> span = opTarget.getSpan();
@@ -1880,7 +1883,7 @@ class ReadWriteManager {
 		Opinion.OpinionExpression expression = opinion.getOpinionExpression();
 		if (expression != null) {
 		    Element opinionExpressionElem = new Element("opinion_expression");
-		    Comment comment = new Comment(cleanUnicode(opinion.getSpanStr(opinion.getOpinionExpression().getSpan())));
+		    Comment comment = new Comment(StringEscapeUtils.escapeXml11(opinion.getSpanStr(opinion.getOpinionExpression().getSpan())));
 		    opinionExpressionElem.addContent(comment);
 		    if (expression.hasPolarity()) {
 			opinionExpressionElem.setAttribute("polarity", expression.getPolarity());
@@ -1923,7 +1926,7 @@ class ReadWriteManager {
 	if (relations.size() > 0) {
 	    Element relationsElem = new Element("relations");
 	    for (Relation relation : relations) {
-		Comment comment = new Comment(cleanUnicode(relation.getStr()));
+		Comment comment = new Comment(StringEscapeUtils.escapeXml11(relation.getStr()));
 		relationsElem.addContent(comment);
 		Element relationElem = new Element("relation");
 		relationElem.setAttribute("id", relation.getId());
@@ -1941,7 +1944,7 @@ class ReadWriteManager {
 	if (predicates.size() > 0) {
 	    Element predicatesElem = new Element("srl");
 	    for (Predicate predicate : predicates) {
-		Comment predicateComment = new Comment(cleanUnicode(predicate.getStr()));
+		Comment predicateComment = new Comment(StringEscapeUtils.escapeXml11(predicate.getStr()));
 		predicatesElem.addContent(predicateComment);
 		Element predicateElem = new Element("predicate");
 		predicateElem.setAttribute("id", predicate.getId());
@@ -1953,7 +1956,7 @@ class ReadWriteManager {
 		}
 		Span<Term> span = predicate.getSpan();
 		if (span.getTargets().size() > 0) {
-		    Comment spanComment = new Comment(cleanUnicode(predicate.getSpanStr()));
+		    Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(predicate.getSpanStr()));
 		    Element spanElem = new Element("span");
 		    predicateElem.addContent(spanComment);
 		    predicateElem.addContent(spanElem);
@@ -1977,7 +1980,7 @@ class ReadWriteManager {
 		    roleElem.setAttribute("semRole", role.getSemRole());
 		    Span<Term> roleSpan = role.getSpan();
 		    if (roleSpan.getTargets().size() > 0) {
-			Comment spanComment = new Comment(cleanUnicode(role.getStr()));
+			Comment spanComment = new Comment(StringEscapeUtils.escapeXml11(role.getStr()));
 			Element spanElem = new Element("span");
 			roleElem.addContent(spanComment);
 			roleElem.addContent(spanElem);
@@ -2055,7 +2058,7 @@ class ReadWriteManager {
 			nodeElem.setAttribute("id", node.getId());
 			nodeElem.addContent(createTermSpanElem(node.getSpan()));
 			// Comment
-			Comment tStrCom = new Comment(cleanUnicode(node.getStr()));
+			Comment tStrCom = new Comment(StringEscapeUtils.escapeXml11(node.getStr()));
 			treeElem.addContent(tStrCom);
 			treeElem.addContent(nodeElem);
 		    }
@@ -2085,7 +2088,7 @@ class ReadWriteManager {
 		if (tempRel instanceof TLink) {
 		    TLink tLink = (TLink)tempRel;
 		    Comment tLinkComment = new Comment
-			(cleanUnicode(tLink.getRelType() + "(" + tLink.getFrom().getId() + ", " + tLink.getTo().getId() + ")"));
+			(StringEscapeUtils.escapeXml11(tLink.getRelType() + "(" + tLink.getFrom().getId() + ", " + tLink.getTo().getId() + ")"));
 		    tempRelsElem.addContent(tLinkComment);
 		    Element tLinkElem = new Element("tlink");
 		    tLinkElem.setAttribute("id", tLink.getId());
@@ -2128,7 +2131,7 @@ class ReadWriteManager {
 		    commentStr += cLink.getRelType();
 		}
 		commentStr += "(" + cLink.getFrom().getId() + ", " + cLink.getTo().getId() + ")";
-		Comment cLinkComment = new Comment(cleanUnicode(commentStr));
+		Comment cLinkComment = new Comment(StringEscapeUtils.escapeXml11(commentStr));
 		cLinksElem.addContent(cLinkComment);
 		Element cLinkElem = new Element("clink");
 		cLinkElem.setAttribute("id", cLink.getId());
@@ -2221,7 +2224,8 @@ class ReadWriteManager {
 	Term head;
 	String termcase;
 	if (!isComponent) {
-	    Comment termComment = new Comment(cleanUnicode(term.getStr()));
+	    Comment termComment = new Comment(StringEscapeUtils.escapeXml11(term.getStr()));
+		//Comment termComment = new Comment(term.getStr());
 	    termsElem.addContent(termComment);
 	}
 	String tag = (isComponent) ? "component" : "term";
@@ -2231,7 +2235,8 @@ class ReadWriteManager {
 	    termElem.setAttribute("type", term.getType());
 	}
 	if (term.hasLemma()) {
-	    termElem.setAttribute("lemma", term.getLemma());
+		//System.err.println(StringEscapeUtils.escapeHtml4(term.getLemma())+" "+StringEscapeUtils.escapeXml11(term.getLemma()));
+	    termElem.setAttribute("lemma", StringEscapeUtils.escapeXml11(term.getLemma()));
 	}
 	if (term.hasPos()) {
 	    termElem.setAttribute("pos", term.getPos());
@@ -2391,10 +2396,4 @@ class ReadWriteManager {
 	return Integer.valueOf(matcher.group(1));
     }
 
-    /**
-     * Removes unicode chars greater than u10000 (Java comments don't allow them).
-     */
-    private static String cleanUnicode(String str) {
-	return str.replaceAll("[\\x{02710}-\\x{FFFFF}]", "");
-    }
 }


### PR DESCRIPTION
I've had some problems with reading and writing NAF files containing malformed XML characters (introduced by the pos-tagged). This version solves those issues by means of org.apache.commons.lang3.StringEscapeUtils. I've made changes to the ReadWriteManager class and updated pom file with the new dependency. 

You may run some tests before merging though.

Cheers!

Iñaki.

