### PR TITLE
Document additional entity type

### DIFF
--- a/src/main/java/ixa/kaflib/Entity.java
+++ b/src/main/java/ixa/kaflib/Entity.java
@@ -21,6 +21,7 @@ public class Entity extends IdentifiableAnnotation implements Relational, Senten
      * - Money
      * - Percent
      * - Misc
+     * - GPE (stands for Geo-Political Entity)
      */ 
     private String type;
     


### PR DESCRIPTION
Extracting named entities from a phrase like "A mi me piace Roma." tags Rome as a Geo-Political Entity (GPE) instead of a Location Entity. Updating the documentation to reflect this.

Example KAF document:

```xml
<NAF xml:lang="it" version="v1.naf">
  <nafHeader />
  <text>
    <wf id="w1" offset="0" length="1" sent="1" para="1">A</wf>
    <wf id="w2" offset="2" length="2" sent="1" para="1">mi</wf>
    <wf id="w3" offset="5" length="2" sent="1" para="1">me</wf>
    <wf id="w4" offset="8" length="5" sent="1" para="1">piace</wf>
    <wf id="w5" offset="14" length="4" sent="1" para="1">Roma</wf>
    <wf id="w6" offset="18" length="1" sent="1" para="1">.</wf>
  </text>
  <terms>
    <!--A-->
    <term id="t1" type="close" lemma="a" pos="P" morphofeat="ADP">
      <span>
        <target id="w1" />
      </span>
    </term>
    <!--mi-->
    <term id="t2" type="close" lemma="mi" pos="Q" morphofeat="PRON">
      <span>
        <target id="w2" />
      </span>
    </term>
    <!--me-->
    <term id="t3" type="close" lemma="me" pos="Q" morphofeat="PRON">
      <span>
        <target id="w3" />
      </span>
    </term>
    <!--piace-->
    <term id="t4" type="open" lemma="piacere" pos="V" morphofeat="VERB">
      <span>
        <target id="w4" />
      </span>
    </term>
    <!--Roma-->
    <term id="t5" type="close" lemma="roma" pos="R" morphofeat="PROPN">
      <span>
        <target id="w5" />
      </span>
    </term>
    <!--.-->
    <term id="t6" type="close" lemma="." pos="O" morphofeat="PUNCT">
      <span>
        <target id="w6" />
      </span>
    </term>
  </terms>
  <entities>
    <entity id="e1" type="GPE">
      <references>
        <!--Roma-->
        <span>
          <target id="t5" />
        </span>
      </references>
    </entity>
  </entities>
</NAF>
```